### PR TITLE
将AlbumModel的实例化与查询分开

### DIFF
--- a/easyPhotos/src/main/java/com/huantansheng/easyphotos/Builder/AlbumBuilder.java
+++ b/easyPhotos/src/main/java/com/huantansheng/easyphotos/Builder/AlbumBuilder.java
@@ -315,7 +315,6 @@ public class AlbumBuilder {
     private static void clear() {
         Result.clear();
         Setting.clear();
-        AlbumModel.clear();
         instance = null;
     }
 

--- a/easyPhotos/src/main/java/com/huantansheng/easyphotos/models/album/AlbumModel.java
+++ b/easyPhotos/src/main/java/com/huantansheng/easyphotos/models/album/AlbumModel.java
@@ -2,6 +2,7 @@ package com.huantansheng.easyphotos.models.album;
 
 import android.app.Activity;
 import android.content.ContentResolver;
+import android.content.Context;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.Build;
@@ -25,6 +26,9 @@ import java.util.ArrayList;
 /**
  * 专辑模型
  * Created by huan on 2017/10/20.
+ *
+ * Modified by Eagle on 2018/08/31.
+ * 修改内容：将AlbumModel的实例化与数据查询分开
  */
 
 public class AlbumModel {
@@ -32,45 +36,40 @@ public class AlbumModel {
     public static AlbumModel instance;
     public Album album;
 
-
-    /**
-     * AlbumModel构造方法
-     *
-     * @param act      调用专辑的活动实体类
-     * @param callBack 初始化全部专辑后的回调
-     */
-    private AlbumModel(final Activity act, AlbumModel.CallBack callBack) {
+    private AlbumModel() {
         album = new Album();
-        init(act, callBack);
     }
 
-    public static AlbumModel getInstance(final Activity act, AlbumModel.CallBack callBack) {
+    public static AlbumModel getInstance() {
         if (null == instance) {
             synchronized (AlbumModel.class) {
                 if (null == instance) {
-                    instance = new AlbumModel(act, callBack);
+                    instance = new AlbumModel();
                 }
             }
         }
         return instance;
     }
 
-    public static void clear() {
-        instance = null;
-    }
-
-    private void init(final Activity act, final CallBack callBack) {
+    /**
+     * 专辑查询
+     *
+     * @param context 调用查询方法的context
+     * @param callBack 查询完成后的回调
+     */
+    public void query(final Context context, final CallBack callBack) {
         new Thread(new Runnable() {
             @Override
             public void run() {
-                initAlbum(act);
+                album = new Album();
+                initAlbum(context);
                 if (null != callBack)
                     callBack.onAlbumWorkedCallBack();
             }
         }).start();
     }
 
-    private void initAlbum(Activity act) {
+    private void initAlbum(Context context) {
         if (Setting.selectedPhotos.size() > Setting.count) {
             throw new RuntimeException("AlbumBuilder: 默认勾选的图片张数不能大于设置的选择数！" + "|默认勾选张数：" + Setting.selectedPhotos.size() + "|设置的选择数：" + Setting.count);
         }
@@ -79,7 +78,7 @@ public class AlbumModel {
 
         String sortOrder = MediaStore.Images.Media.DATE_TAKEN + " DESC";
 
-        ContentResolver contentResolver = act.getContentResolver();
+        ContentResolver contentResolver = context.getContentResolver();
         String[] projections = null;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
             projections = new String[]{
@@ -105,7 +104,7 @@ public class AlbumModel {
         if (cursor == null) {
 //            Log.d(TAG, "call: " + "Empty photos");
         } else if (cursor.moveToFirst()) {
-            String albumItem_all_name = act.getString(R.string.selector_folder_all_easy_photos);
+            String albumItem_all_name = context.getString(R.string.selector_folder_all_easy_photos);
             int pathCol = cursor.getColumnIndex(MediaStore.Images.Media.DATA);
             int nameCol = cursor.getColumnIndex(MediaStore.Images.Media.DISPLAY_NAME);
             int DateCol = cursor.getColumnIndex(MediaStore.Images.Media.DATE_TAKEN);

--- a/easyPhotos/src/main/java/com/huantansheng/easyphotos/ui/EasyPhotosActivity.java
+++ b/easyPhotos/src/main/java/com/huantansheng/easyphotos/ui/EasyPhotosActivity.java
@@ -153,7 +153,6 @@ public class EasyPhotosActivity extends AppCompatActivity implements AlbumItemsA
             return;
         }
         permissionView.setVisibility(View.GONE);
-        AlbumModel.clear();
         AlbumModel.CallBack albumModelCallBack = new AlbumModel.CallBack() {
             @Override
             public void onAlbumWorkedCallBack() {
@@ -165,7 +164,8 @@ public class EasyPhotosActivity extends AppCompatActivity implements AlbumItemsA
                 });
             }
         };
-        albumModel = AlbumModel.getInstance(this, albumModelCallBack);
+        albumModel = AlbumModel.getInstance();
+        albumModel.query(this, albumModelCallBack);
     }
 
     protected String[] getNeedPermissions() {

--- a/easyPhotos/src/main/java/com/huantansheng/easyphotos/ui/PuzzleSelectorActivity.java
+++ b/easyPhotos/src/main/java/com/huantansheng/easyphotos/ui/PuzzleSelectorActivity.java
@@ -76,7 +76,8 @@ public class PuzzleSelectorActivity extends AppCompatActivity implements View.On
                 SystemUtils.getInstance().setStatusDark(this, true);
             }
         }
-        albumModel = AlbumModel.getInstance(this, null);
+        albumModel = AlbumModel.getInstance();
+        albumModel.query(this, null);
         if (null == albumModel||albumModel.getAlbumItems().isEmpty()) {
             finish();
             return;


### PR DESCRIPTION
原先的方案每次查询都需要clear()然后初始化，操作麻烦，不太符合单例模式的使用场景。