### PR TITLE
全部视频文件夹视频重复，点击视频无法播放，右下角相机按钮显示问题

### DIFF
--- a/demo/src/main/java/com/huantansheng/easyphotos/demo/SampleActivity.java
+++ b/demo/src/main/java/com/huantansheng/easyphotos/demo/SampleActivity.java
@@ -246,7 +246,6 @@ public class SampleActivity extends AppCompatActivity
                 EasyPhotos.createAlbum(this, true, GlideEngine.getInstance())
                         .setFileProviderAuthority("com.huantansheng.easyphotos.demo.fileprovider")
                         .setCount(9)
-                        .setVideoMinSecond(10)
                         .filter(Type.VIDEO)
                         .start(101);
                 break;

--- a/easyPhotos/src/main/java/com/huantansheng/easyphotos/models/album/AlbumModel.java
+++ b/easyPhotos/src/main/java/com/huantansheng/easyphotos/models/album/AlbumModel.java
@@ -6,7 +6,6 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.os.Build;
 import android.provider.MediaStore;
-import android.provider.Settings;
 import android.text.TextUtils;
 
 import com.huantansheng.easyphotos.R;
@@ -28,7 +27,6 @@ import java.util.ArrayList;
  * Modified by Eagle on 2018/08/31.
  * 修改内容：将AlbumModel的实例化与数据查询分开
  */
-
 public class AlbumModel {
     private static final String TAG = "AlbumModel";
     public static AlbumModel instance;
@@ -86,7 +84,7 @@ public class AlbumModel {
         };
 
         ContentResolver contentResolver = context.getContentResolver();
-        String[] projections = null;
+        String[] projections;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
             projections = new String[]{MediaStore.Files.FileColumns._ID, MediaStore.MediaColumns.DATA,
                     MediaStore.MediaColumns.DISPLAY_NAME, MediaStore.MediaColumns.DATE_MODIFIED,
@@ -189,7 +187,7 @@ public class AlbumModel {
                 // 把图片全部放进“全部”专辑
                 album.getAlbumItem(albumItem_all_name).addImageItem(imageItem);
 
-                if (Setting.showVideo && isVideo) {
+                if (Setting.showVideo && isVideo && !albumItem_video_name.equals(albumItem_all_name)) {
                     album.addAlbumItem(albumItem_video_name, "", path);
                     album.getAlbumItem(albumItem_video_name).addImageItem(imageItem);
                 }

--- a/easyPhotos/src/main/java/com/huantansheng/easyphotos/ui/EasyPhotosActivity.java
+++ b/easyPhotos/src/main/java/com/huantansheng/easyphotos/ui/EasyPhotosActivity.java
@@ -65,8 +65,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.Locale;
 
-import static com.huantansheng.easyphotos.setting.Setting.isBottomRightCamera;
-
 public class EasyPhotosActivity extends AppCompatActivity implements AlbumItemsAdapter
         .OnClickListener, PhotosAdapter.OnClickListener, AdListener, View.OnClickListener {
 
@@ -146,9 +144,9 @@ public class EasyPhotosActivity extends AppCompatActivity implements AlbumItemsA
 
     private void initSomeViews() {
         mBottomBar = findViewById(R.id.m_bottom_bar);
-        permissionView = (RelativeLayout) findViewById(R.id.rl_permissions_view);
-        tvPermission = (TextView) findViewById(R.id.tv_permission);
-        rootViewAlbumItems = (RelativeLayout) findViewById(R.id.root_view_album_items);
+        permissionView = findViewById(R.id.rl_permissions_view);
+        tvPermission = findViewById(R.id.tv_permission);
+        rootViewAlbumItems = findViewById(R.id.root_view_album_items);
         findViewById(R.id.iv_second_menu).setVisibility(Setting.showPuzzleMenu || Setting
                 .showCleanMenu || Setting.showOriginalMenu ? View.VISIBLE : View.GONE);
         setClick(R.id.iv_back);
@@ -270,7 +268,7 @@ public class EasyPhotosActivity extends AppCompatActivity implements AlbumItemsA
             createCameraTempImageFile();
             if (mTempImageFile != null && mTempImageFile.exists()) {
 
-                Uri imageUri = null;
+                Uri imageUri;
                 if (Build.VERSION.SDK_INT >= 24) {
                     imageUri = FileProvider.getUriForFile(this, Setting.fileProviderAuthority,
                             mTempImageFile);//通过FileProvider创建一个content类型的Uri
@@ -485,19 +483,19 @@ public class EasyPhotosActivity extends AppCompatActivity implements AlbumItemsA
         if (Setting.hasPhotosAd()) {
             findViewById(R.id.m_tool_bar_bottom_line).setVisibility(View.GONE);
         }
-        ivCamera = (ImageView) findViewById(R.id.fab_camera);
-        if (Setting.isShowCamera && isBottomRightCamera()) {
+        ivCamera = findViewById(R.id.fab_camera);
+        if (Setting.isShowCamera && Setting.isBottomRightCamera()) {
             ivCamera.setVisibility(View.VISIBLE);
         }
         if (!Setting.showPuzzleMenu) {
             findViewById(R.id.tv_puzzle).setVisibility(View.GONE);
         }
-        mSecondMenus = (LinearLayout) findViewById(R.id.m_second_level_menu);
+        mSecondMenus = findViewById(R.id.m_second_level_menu);
         int columns = getResources().getInteger(R.integer.photos_columns_easy_photos);
-        tvAlbumItems = (PressedTextView) findViewById(R.id.tv_album_items);
+        tvAlbumItems = findViewById(R.id.tv_album_items);
         tvAlbumItems.setText(albumModel.getAlbumItems().get(0).name);
-        tvDone = (PressedTextView) findViewById(R.id.tv_done);
-        rvPhotos = (RecyclerView) findViewById(R.id.rv_photos);
+        tvDone = findViewById(R.id.tv_done);
+        rvPhotos = findViewById(R.id.rv_photos);
         ((SimpleItemAnimator) rvPhotos.getItemAnimator()).setSupportsChangeAnimations(false);
         //去除item更新的闪光
         photoList.clear();
@@ -506,7 +504,7 @@ public class EasyPhotosActivity extends AppCompatActivity implements AlbumItemsA
         if (Setting.hasPhotosAd()) {
             photoList.add(index, Setting.photosAdView);
         }
-        if (Setting.isShowCamera && !isBottomRightCamera()) {
+        if (Setting.isShowCamera && !Setting.isBottomRightCamera()) {
             if (Setting.hasPhotosAd()) index = 1;
             photoList.add(index, null);
         }
@@ -527,13 +525,13 @@ public class EasyPhotosActivity extends AppCompatActivity implements AlbumItemsA
         }
         rvPhotos.setLayoutManager(gridLayoutManager);
         rvPhotos.setAdapter(photosAdapter);
-        tvOriginal = (TextView) findViewById(R.id.tv_original);
+        tvOriginal = findViewById(R.id.tv_original);
         if (Setting.showOriginalMenu) {
             processOriginalMenu();
         } else {
             tvOriginal.setVisibility(View.GONE);
         }
-        tvPreview = (PressedTextView) findViewById(R.id.tv_preview);
+        tvPreview = findViewById(R.id.tv_preview);
 
         initAlbumItems();
         shouldShowMenuDone();
@@ -551,7 +549,7 @@ public class EasyPhotosActivity extends AppCompatActivity implements AlbumItemsA
 
     private void initAlbumItems() {
 
-        rvAlbumItems = (RecyclerView) findViewById(R.id.rv_album_items);
+        rvAlbumItems = findViewById(R.id.rv_album_items);
         albumItemList.clear();
         albumItemList.addAll(albumModel.getAlbumItems());
 
@@ -614,10 +612,14 @@ public class EasyPhotosActivity extends AppCompatActivity implements AlbumItemsA
         }
         if (View.VISIBLE == mSecondMenus.getVisibility()) {
             mSecondMenus.setVisibility(View.INVISIBLE);
-            if (Setting.isShowCamera) ivCamera.setVisibility(View.VISIBLE);
+            if (Setting.isShowCamera && Setting.isBottomRightCamera()) {
+                ivCamera.setVisibility(View.VISIBLE);
+            }
         } else {
             mSecondMenus.setVisibility(View.VISIBLE);
-            if (Setting.isShowCamera) ivCamera.setVisibility(View.INVISIBLE);
+            if (Setting.isShowCamera && Setting.isBottomRightCamera()) {
+                ivCamera.setVisibility(View.INVISIBLE);
+            }
         }
     }
 
@@ -711,7 +713,7 @@ public class EasyPhotosActivity extends AppCompatActivity implements AlbumItemsA
         if (Setting.hasPhotosAd()) {
             photoList.add(index, Setting.photosAdView);
         }
-        if (Setting.isShowCamera && !isBottomRightCamera()) {
+        if (Setting.isShowCamera && !Setting.isBottomRightCamera()) {
             if (Setting.hasPhotosAd()) index = 1;
             photoList.add(index, null);
         }

--- a/easyPhotos/src/main/java/com/huantansheng/easyphotos/ui/adapter/PhotosAdapter.java
+++ b/easyPhotos/src/main/java/com/huantansheng/easyphotos/ui/adapter/PhotosAdapter.java
@@ -1,6 +1,7 @@
 package com.huantansheng.easyphotos.ui.adapter;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
@@ -21,13 +22,10 @@ import com.huantansheng.easyphotos.utils.media.DurationUtils;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 
-import static com.huantansheng.easyphotos.setting.Setting.isBottomRightCamera;
-
 /**
  * 专辑相册适配器
  * Created by huan on 2017/10/23.
  */
-
 public class PhotosAdapter extends RecyclerView.Adapter {
     private static final int TYPE_AD = 0;
     private static final int TYPE_CAMERA = 1;
@@ -53,8 +51,9 @@ public class PhotosAdapter extends RecyclerView.Adapter {
         notifyDataSetChanged();
     }
 
+    @NonNull
     @Override
-    public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+    public RecyclerView.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
         switch (viewType) {
             case TYPE_AD:
                 return new AdViewHolder(mInflater.inflate(R.layout.item_ad_easy_photos, parent, false));
@@ -66,7 +65,7 @@ public class PhotosAdapter extends RecyclerView.Adapter {
     }
 
     @Override
-    public void onBindViewHolder(final RecyclerView.ViewHolder holder, int position) {
+    public void onBindViewHolder(@NonNull final RecyclerView.ViewHolder holder, int position) {
         final int p = position;
         if (holder instanceof PhotoViewHolder) {
             final Photo item = (Photo) dataList.get(p);
@@ -98,7 +97,7 @@ public class PhotosAdapter extends RecyclerView.Adapter {
                     if (Setting.hasPhotosAd()) {
                         realPosition--;
                     }
-                    if (Setting.isShowCamera && !isBottomRightCamera()) {
+                    if (Setting.isShowCamera && !Setting.isBottomRightCamera()) {
                         realPosition--;
                     }
                     listener.onPhotoClick(p, realPosition);
@@ -239,11 +238,11 @@ public class PhotosAdapter extends RecyclerView.Adapter {
             if (Setting.hasPhotosAd()) {
                 return TYPE_AD;
             }
-            if (Setting.isShowCamera && !isBottomRightCamera()) {
+            if (Setting.isShowCamera && !Setting.isBottomRightCamera()) {
                 return TYPE_CAMERA;
             }
         }
-        if (1 == position && !isBottomRightCamera()) {
+        if (1 == position && !Setting.isBottomRightCamera()) {
             if (Setting.hasPhotosAd() && Setting.isShowCamera) {
                 return TYPE_CAMERA;
             }
@@ -266,7 +265,7 @@ public class PhotosAdapter extends RecyclerView.Adapter {
 
         CameraViewHolder(View itemView) {
             super(itemView);
-            this.flCamera = (FrameLayout) itemView.findViewById(R.id.fl_camera);
+            this.flCamera = itemView.findViewById(R.id.fl_camera);
         }
     }
 
@@ -278,10 +277,10 @@ public class PhotosAdapter extends RecyclerView.Adapter {
 
         PhotoViewHolder(View itemView) {
             super(itemView);
-            this.ivPhoto = (PressedImageView) itemView.findViewById(R.id.iv_photo);
-            this.tvSelector = (TextView) itemView.findViewById(R.id.tv_selector);
+            this.ivPhoto = itemView.findViewById(R.id.iv_photo);
+            this.tvSelector = itemView.findViewById(R.id.tv_selector);
             this.vSelector = itemView.findViewById(R.id.v_selector);
-            this.tvType = (TextView) itemView.findViewById(R.id.tv_type);
+            this.tvType = itemView.findViewById(R.id.tv_type);
         }
     }
 }

--- a/easyPhotos/src/main/java/com/huantansheng/easyphotos/ui/adapter/PreviewPhotosAdapter.java
+++ b/easyPhotos/src/main/java/com/huantansheng/easyphotos/ui/adapter/PreviewPhotosAdapter.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Build;
+import android.support.annotation.NonNull;
 import android.support.v4.content.FileProvider;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
@@ -25,7 +26,6 @@ import java.util.ArrayList;
  * 大图预览界面图片集合的适配器
  * Created by huan on 2017/10/26.
  */
-
 public class PreviewPhotosAdapter extends RecyclerView.Adapter<PreviewPhotosAdapter.PreviewPhotosViewHolder> {
     private ArrayList<Photo> photos;
     private OnClickListener listener;
@@ -43,13 +43,14 @@ public class PreviewPhotosAdapter extends RecyclerView.Adapter<PreviewPhotosAdap
         this.listener = listener;
     }
 
+    @NonNull
     @Override
-    public PreviewPhotosViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+    public PreviewPhotosViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
         return new PreviewPhotosViewHolder(inflater.inflate(R.layout.item_preview_photo_easy_photos, parent, false));
     }
 
     @Override
-    public void onBindViewHolder(final PreviewPhotosViewHolder holder, int position) {
+    public void onBindViewHolder(@NonNull final PreviewPhotosViewHolder holder, int position) {
         final String path = photos.get(position).path;
         final String type = photos.get(position).type;
 
@@ -86,15 +87,16 @@ public class PreviewPhotosAdapter extends RecyclerView.Adapter<PreviewPhotosAdap
     private void toPlayVideo(View v, String path, String type) {
         Context context = v.getContext();
         Intent intent = new Intent(Intent.ACTION_VIEW);
-        Uri uri = getUri(context, path);
+        Uri uri = getUri(context, path, intent);
         intent.setDataAndType(uri, type);
-        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         context.startActivity(intent);
     }
 
-    private Uri getUri(Context context, String path) {
+    private Uri getUri(Context context, String path, Intent intent) {
         File file = new File(path);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+            intent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
             return FileProvider.getUriForFile(context, Setting.fileProviderAuthority, file);
         } else {
             return Uri.fromFile(file);
@@ -112,8 +114,8 @@ public class PreviewPhotosAdapter extends RecyclerView.Adapter<PreviewPhotosAdap
 
         PreviewPhotosViewHolder(View itemView) {
             super(itemView);
-            ivPhoto = (PhotoView) itemView.findViewById(R.id.iv_photo);
-            ivPlay = (ImageView) itemView.findViewById(R.id.iv_play);
+            ivPhoto = itemView.findViewById(R.id.iv_photo);
+            ivPlay = itemView.findViewById(R.id.iv_play);
         }
     }
 }

--- a/easyPhotos/src/main/java/com/huantansheng/easyphotos/utils/media/MediaScannerConnectionUtils.java
+++ b/easyPhotos/src/main/java/com/huantansheng/easyphotos/utils/media/MediaScannerConnectionUtils.java
@@ -1,6 +1,5 @@
 package com.huantansheng.easyphotos.utils.media;
 
-import android.app.Application;
 import android.content.Context;
 import android.media.MediaScannerConnection;
 


### PR DESCRIPTION
1.仅显示视频时，全部视频文件夹视频重复添加问题；
2.点击视频无法播放问题；
3.当相机按钮位置在图片第一张时，点击相册页底部中间的编辑按钮会导致右下角相机按钮也显示出来。